### PR TITLE
Fix PaidStorage Report status checking method

### DIFF
--- a/src/API/Endpoint/Subpoint/PaidStorage.php
+++ b/src/API/Endpoint/Subpoint/PaidStorage.php
@@ -50,7 +50,7 @@ class PaidStorage
     public function checkReportStatus(string $task_id): string
     {
         $result = $this->Analitics->getRequest('/api/v1/paid_storage/tasks/' . $task_id . '/status');
-        return $result->status;
+        return $result->data->status;
     }
     
     /**


### PR DESCRIPTION
Change `$result->status` to  `$result->data->status` because structure of response look like this: 
```json
{
  "data": {
    "id": "cad56ec5-91ec-43a2-b5e8-efcf244cf309",
    "status": "done"
  }
}
```
[WB API DOC](https://dev.wildberries.ru/openapi/reports#tag/Platnoe-hranenie/paths/~1api~1v1~1paid_storage~1tasks~1%7Btask_id%7D~1status/get)